### PR TITLE
Added as24ArticleType to whitelisted cookies

### DIFF
--- a/src/js/showcar-clean-cookies.js
+++ b/src/js/showcar-clean-cookies.js
@@ -49,7 +49,8 @@ const whiteList = [
     '__ut',
     'as24_identity',
     'noauth',
-    'random'
+    'random',
+    'as24ArticleType'
 ];
 
 const deleteCookieByName = function(cookie) {


### PR DESCRIPTION
/cc @AutoScout24/web-experience

## Description
This cookie is related to ENG-1881 and is used to store last selected tab of home page search mask.
